### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -27,7 +27,7 @@ class Graph(object):
     def __repr__(self):
         name = self.get_name()
         nb_nodes = self.get_nb_nodes()
-        s = 'Graphe %s comprenant %d noeuds' % (name, nb_nodes)
+        s = 'Graphe {0!s} comprenant {1:d} noeuds'.format(name, nb_nodes)
         for node in self.get_nodes():
             s += '\n  ' + repr(node)
         return s
@@ -39,6 +39,6 @@ if __name__ == '__main__':
 
     G = Graph(name='Graphe test')
     for k in range(5):
-        G.add_node(Node(name='Noeud test %d' % k))
+        G.add_node(Node(name='Noeud test {0:d}'.format(k)))
 
     print G

--- a/node.py
+++ b/node.py
@@ -27,7 +27,7 @@ class Node(object):
         id = self.get_id()
         name = self.get_name()
         data = self.get_data()
-        s  = 'Noeud %s (id %d)' % (name, id)
+        s  = 'Noeud {0!s} (id {1:d})'.format(name, id)
         s += ' (donnees: ' + repr(data) + ')'
         return s
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:Yaakoubi:TSP?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:Yaakoubi:TSP?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
